### PR TITLE
add port for home and admin apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,18 @@ npx nx run-many -t <target1> <target2>
 npx nx run-many -t <target1> <target2> -p <proj1> <proj2>
 ```
 
+Running e2e in parallel seems to not be working locally due to port overriding
+
+```
+npx nx run-many -t <target1> <target2> --parallel=false --skip-nx-cache
+# ex: npx nx run-many -t e2e --parallel=false --skip-nx-cache
+```
+
 Targets can be defined in the `package.json` or `projects.json`. Learn more [in the docs](https://nx.dev/features/run-tasks).
+
+## Misc
+
+After adding a port the app project.json serving section, may need to re-run npm install for changes to take effect.
 
 ## Set up CI!
 

--- a/apps/admin-e2e/playwright.config.ts
+++ b/apps/admin-e2e/playwright.config.ts
@@ -4,7 +4,7 @@ import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4400';
 
 /**
  * Read environment variables from file.
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npx nx serve admin',
-    url: 'http://localhost:4200',
+    url: 'http://localhost:4400',
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },

--- a/apps/admin/project.json
+++ b/apps/admin/project.json
@@ -56,7 +56,8 @@
           "buildTarget": "admin:build:production"
         },
         "development": {
-          "buildTarget": "admin:build:development"
+          "buildTarget": "admin:build:development",
+          "port": 4400
         }
       },
       "defaultConfiguration": "development"

--- a/apps/home-e2e/playwright.config.ts
+++ b/apps/home-e2e/playwright.config.ts
@@ -4,7 +4,7 @@ import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4300';
 
 /**
  * Read environment variables from file.
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npx nx serve home',
-    url: 'http://localhost:4200',
+    url: 'http://localhost:4300',
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },

--- a/apps/home/project.json
+++ b/apps/home/project.json
@@ -56,7 +56,8 @@
           "buildTarget": "home:build:production"
         },
         "development": {
-          "buildTarget": "home:build:development"
+          "buildTarget": "home:build:development",
+          "port": 4300
         }
       },
       "defaultConfiguration": "development"


### PR DESCRIPTION
trying to resolve why run-many command (in parallel) is not able to run both apps in e2e because of port overriding. doesn't quite work, but saving work.